### PR TITLE
Fix incorrect reset-call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ jest.spyOn(someObject, 'aMethod');
 reset both, history and behavior:
 
 ```js
-stub.resetHistory();
+stub.reset();
 ```
 
 reset call history:


### PR DESCRIPTION
There's a typo here - the function that resets both are just `reset`.

https://github.com/sinonjs/sinon/blob/main/lib/sinon/stub.js#L202